### PR TITLE
Added the minVersion tag

### DIFF
--- a/src/main/resources/radon.mixins.json
+++ b/src/main/resources/radon.mixins.json
@@ -1,5 +1,6 @@
 {
     "required": true,
+    "minVersion": "0.8",
     "package": "net.caffeinemc.phosphor.mixin",
 	"refmap": "radon-refmap.json",
     "compatibilityLevel": "JAVA_17",


### PR DESCRIPTION
I added this tag to prevent this error:
```
[main/ERROR]: Mixin config radon.mixins.json does not specify "minVersion" property
```
so it is fixed.